### PR TITLE
ci: add PR title validation workflow using Conventional Commits

### DIFF
--- a/.github/workflows/pr-naming-conventions.yml
+++ b/.github/workflows/pr-naming-conventions.yml
@@ -1,0 +1,44 @@
+name: PR Naming Conventions
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+jobs:
+  semantic-pull-request:
+    name: Validate PR Title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR title follows Conventional Commit format
+        uses: amannn/action-semantic-pull-request@v5.5.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Configure allowed types
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            test
+            chore
+            ci
+            build
+            revert
+            ci-cd
+            perf
+            release
+            deps
+            infra
+            security
+            env
+            i18n
+            ux
+            config
+            assets
+            meta
+          # Require scope (optional)
+          requireScope: false
+          # Disable validation of commits
+          validateSingleCommit: false


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to enforce consistent naming conventions for pull requests. The workflow validates PR titles against the Conventional Commit format to ensure clarity and standardization.

GitHub Actions Workflow Addition:

* [`.github/workflows/pr-naming-conventions.yml`](diffhunk://#diff-ebfb51dc147d40ac47b7e04f3004f8947a20a57ff34cb96e6da6d7c217c2e25fR1-R44): Added a new workflow named "PR Naming Conventions" that triggers on pull request events (`opened`, `edited`, `synchronize`). It uses the `amannn/action-semantic-pull-request` action to validate PR titles against a predefined list of allowed types, such as `feat`, `fix`, `docs`, and others. Scope validation and single commit validation are disabled.