### PR TITLE
fix: Limit inactive user email notifications to reduce spam

### DIFF
--- a/backend/app/db/mongodb/indexes.py
+++ b/backend/app/db/mongodb/indexes.py
@@ -133,6 +133,8 @@ async def create_user_indexes():
             users_collection.create_index("cached_at", sparse=True),
             # Activity tracking index for inactive user queries
             users_collection.create_index("last_active_at", sparse=True),
+            # Inactive email tracking index (sparse since not all users have this field)
+            users_collection.create_index("last_inactive_email_sent", sparse=True),
         )
 
         logger.info("Created user indexes")


### PR DESCRIPTION
Implement a system to track and limit email notifications for inactive users, ensuring no more than two emails are sent within specified timeframes. Update the user schema and email sending logic to support this feature.