### PR TITLE
refactor(docker-compose): remove unnecessary reload option and backend volume from gaia-backend service

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -18,7 +18,6 @@ services:
         "0.0.0.0",
         "--port",
         "80",
-        "--reload",
         "--no-access-log",
       ]
     environment:
@@ -27,8 +26,6 @@ services:
       WORKER_TYPE: main_app
     env_file:
       - ./backend/.env
-    volumes:
-      - ./backend:/app
     ports:
       - "8000:80"
     restart: on-failure


### PR DESCRIPTION
This pull request includes changes to the `docker-compose.prod.yml` file to optimize the production configuration by removing unnecessary options and volume mounts.

### Changes to `docker-compose.prod.yml`:

* Removed the `--reload` flag from the service command, as it is typically used for development and not needed in production.

* Removed the volume mount from the `backend` service to prevent unnecessary file syncing in production, ensuring a cleaner and more secure setup.