### PR TITLE
refactor(mail_tool): update email composition data structure for clarity

### DIFF
--- a/backend/app/langchain/tools/mail_tool.py
+++ b/backend/app/langchain/tools/mail_tool.py
@@ -1,6 +1,7 @@
 from typing import Annotated, Any, Dict, List, Optional
 
 from app.config.loggers import chat_logger as logger
+from app.decorators import require_integration, with_doc, with_rate_limiting
 from app.docstrings.langchain.tools.mail_tool_docs import (
     APPLY_LABELS_TO_EMAILS,
     ARCHIVE_EMAILS,
@@ -17,7 +18,6 @@ from app.docstrings.langchain.tools.mail_tool_docs import (
     UNSTAR_EMAILS,
     UPDATE_GMAIL_LABEL,
 )
-from app.decorators import with_doc, with_rate_limiting, require_integration
 from app.langchain.templates.mail_templates import (
     COMPOSE_EMAIL_TEMPLATE,
     process_get_thread_response,
@@ -299,9 +299,19 @@ async def compose_email(
                 }
             )
 
+        emails_data = []
+        for email in emails:
+            emails_data.append(
+                {
+                    "to": email.to,
+                    "subject": email.subject,
+                    "body": email.body,
+                }
+            )
+
         # Progress update for drafting
         writer({"progress": f"Drafting {len(emails)} email(s)..."})
-        writer({"email_compose_data": emails})
+        writer({"email_compose_data": emails_data})
 
         # Generate summary of the composed emails
         if len(emails) == 1:


### PR DESCRIPTION
This pull request refactors the `compose_email` function in `mail_tool.py` to improve the structure of email data handling and makes minor adjustments to import statements for better organization.

### Refactoring of `compose_email` function:

* Modified the `compose_email` function to transform `emails` into a list of dictionaries containing `to`, `subject`, and `body` fields before passing the data to the writer. This ensures a more structured and consistent format for email data.

### Import statement reorganization:

* Reorganized import statements in `mail_tool.py` by grouping `require_integration`, `with_doc`, and `with_rate_limiting` decorators together at the top of the file for better readability and maintainability. [[1]](diffhunk://#diff-ff436b77d8815ba5424d66e49b122aa16a48fb19022ad326b864331764b85938R4) [[2]](diffhunk://#diff-ff436b77d8815ba5424d66e49b122aa16a48fb19022ad326b864331764b85938L20)