### PR TITLE
ci: prevent lockfile changes during CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,8 +31,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pnpm install --no-frozen-lockfile
-          pnpm install
+          pnpm install --frozen-lockfile
 
       - name: Run ESLint with autofix
         run: pnpm lint:fix

--- a/frontend/.prettierignore
+++ b/frontend/.prettierignore
@@ -3,3 +3,4 @@ node_modules
 public
 .husky
 ../docs
+pnpm-lock.yaml


### PR DESCRIPTION
Replaced `pnpm install --no-frozen-lockfile` with `--frozen-lockfile` to ensure lockfile is not regenerated in CI