### PR TITLE
chore: Update release token and import useRouter in useChatStream hook

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,6 +15,6 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           release-type: simple
           config-file: .github/release-please-config.json

--- a/frontend/src/features/chat/hooks/useChatStream.ts
+++ b/frontend/src/features/chat/hooks/useChatStream.ts
@@ -14,12 +14,14 @@ import fetchDate from "@/utils/date/dateUtils";
 
 import { useLoadingText } from "./useLoadingText";
 import { parseStreamData } from "./useStreamDataParser";
+import { useRouter } from "next/navigation";
 
 export const useChatStream = () => {
   const { setIsLoading, setAbortController } = useLoading();
   const { updateConvoMessages, convoMessages } = useConversation();
   const fetchConversations = useFetchConversations();
   const { setLoadingText, resetLoadingText } = useLoadingText();
+  const router = useRouter();
 
   // Unified ref storage
   const refs = useRef({


### PR DESCRIPTION
Replace the GitHub token with a release token in the workflow and import the useRouter hook in the useChatStream hook for improved routing functionality.