### PR TITLE
chore(ci): Enable manual triggering of release workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - develop
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
Add support for manually triggering the release workflow through the `workflow_dispatch` event.