### PR TITLE
chore: update release-please configuration and manifest versions to 0.4.0-beta

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,3 +1,5 @@
 {
-  ".": "0.5.0-beta"
+  ".": "0.4.0-beta",
+  "backend": "0.4.0-beta",
+  "frontend": "0.4.0-beta"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -12,7 +12,8 @@
     ".": {
       "release-type": "simple",
       "changelog-path": "CHANGELOG.md",
-      "include-component-in-tag": false
+      "include-component-in-tag": false,
+      "pull-request-title-pattern": "release: ${version}"
     },
     "backend": {
       "path": "backend",


### PR DESCRIPTION

This pull request updates release management configuration to better support versioning and release automation. The most important changes are grouped below.

Release versioning updates:

* Updated `.release-please-manifest.json` to include separate version entries for `backend` and `frontend`, both set to `0.4.0-beta`, and reverted the root version to `0.4.0-beta`.

Release automation improvements:

* Added a `pull-request-title-pattern` to the root configuration in `release-please-config.json`, ensuring release PRs use the format `release: ${version}` for consistency.