### PR TITLE
fix: update deployment workflows to trigger on push to master

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -1,8 +1,9 @@
 name: Deploy Frontend
 
 on:
-  repository_dispatch:
-    types: [deploy-frontend]
+  push:
+    branches:
+      - master
   workflow_dispatch:
 
 permissions:
@@ -12,7 +13,6 @@ jobs:
   sync_and_deploy:
     runs-on: ubuntu-latest
     environment: production
-    if: github.event.client_payload.ref == 'refs/heads/master'
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,9 @@
 name: Deploy to GCP
 
 on:
-  repository_dispatch:
-    types: [deploy]
+  push:
+    branches:
+      - master
   workflow_dispatch:
 
 permissions:
@@ -18,7 +19,6 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     environment: production
-    if: github.event.client_payload.ref == 'refs/heads/master'
 
     # Needed for OIDC → WIF
     permissions:
@@ -60,7 +60,7 @@ jobs:
               git pull origin master
 
               docker compose -f docker-compose.prod.yml pull
-              
+
               # Recreate only services with updated images
               docker compose -f docker-compose.prod.yml up -d --remove-orphans --no-deps
               docker image prune -f
@@ -81,13 +81,13 @@ jobs:
             --zone=${{ secrets.GCP_ZONE }} \
             --command="
               echo 'Starting Docker cleanup...'
-              
+
               # Remove dangling images
               docker image prune -f
 
               # Remove stopped containers
               docker container prune -f
-              
+
               # Remove unused networks
               docker network prune -f
 
@@ -100,15 +100,23 @@ jobs:
         with:
           webhook_url: ${{ secrets.DISCORD_WEBHOOK }}
           username: "Gaia Deploy Bot"
-          color: "#48f442"
+          color: ${{ job.status == 'success' && '#48f442' || '#ff6b6b' }}
           message: |
-            🚀 **Deployment to GCP**
+            🚀 **Deployment to GCP ${{ job.status == 'success' && 'Completed' || 'Failed' }}**
 
             **Repository:** ${{ github.repository }}
             **Branch:** ${{ github.ref_name }}
             **Commit:** ${{ github.sha }}
             **Status:** ${{ job.status }}
             **Deployed by:** ${{ github.actor }}
-            **Timestamp:** ${{ github.run_id }}
+            **Run ID:** ${{ github.run_id }}
 
-
+      - name: Update deployment status
+        if: always()
+        run: |
+          if [ "${{ job.status }}" == "success" ]; then
+            echo "✅ Deployment completed successfully"
+          else
+            echo "❌ Deployment failed"
+            exit 1
+          fi


### PR DESCRIPTION
This pull request updates the deployment workflows to trigger on pushes to the `master` branch instead of via repository dispatch events, and improves deployment status reporting. These changes streamline the deployment process and provide clearer feedback on deployment outcomes.

**Workflow trigger updates:**

* Changed the triggers for both `deploy-frontend.yml` and `deploy.yml` workflows to run on pushes to the `master` branch, replacing the previous `repository_dispatch` event triggers. This makes deployments automatic when code is pushed to `master`. [[1]](diffhunk://#diff-64f2f74f4d05399d57c48809ad9ec9bc55550bd51d5faf574866753ea4d781dbL4-R6) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L4-R6)

* Removed the conditional check for `github.event.client_payload.ref == 'refs/heads/master'` in both workflows, as deployments now only trigger for the `master` branch. [[1]](diffhunk://#diff-64f2f74f4d05399d57c48809ad9ec9bc55550bd51d5faf574866753ea4d781dbL15) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L21)

**Deployment status reporting improvements:**

* Updated the Discord notification in `deploy.yml` to dynamically set the color and message based on the job status, and clarified the run identifier field.

* Added a new step to `deploy.yml` that prints a success or failure message after deployment and exits with an error code if the deployment fails, improving visibility and error handling.

**Subproject update:**

* Updated the subproject commit for `template-c1-component-next` to the latest version.